### PR TITLE
Add reloadWithAlert to PHConfigLoader and do not show alert on launch

### DIFF
--- a/Phoenix/PHAppDelegate.m
+++ b/Phoenix/PHAppDelegate.m
@@ -33,7 +33,7 @@
 }
 
 - (IBAction) reloadConfig:(id)sender {
-    [self.configLoader reload];
+    [self.configLoader reloadWithAlert];
 }
 
 - (IBAction) showAboutPanel:(id)sender {

--- a/Phoenix/PHConfigLoader.h
+++ b/Phoenix/PHConfigLoader.h
@@ -11,5 +11,6 @@
 @interface PHConfigLoader : NSObject
 
 - (void) reload;
+- (void) reloadWithAlert;
 
 @end

--- a/Phoenix/PHConfigLoader.m
+++ b/Phoenix/PHConfigLoader.m
@@ -52,8 +52,8 @@ static NSString* PHConfigPath = @"~/.phoenix.js";
 
 - (void) setupConfigWatcher {
     self.watcher = [PHPathWatcher watcherFor: [self.configPaths allObjects] handler:^{
-        [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(reload) object:nil];
-        [self performSelector:@selector(reload) withObject:nil afterDelay:0.25];
+        [[self class] cancelPreviousPerformRequestsWithTarget:self selector:@selector(reloadWithAlert) object:nil];
+        [self performSelector:@selector(reloadWithAlert) withObject:nil afterDelay:0.25];
     }];
 }
 
@@ -92,7 +92,10 @@ static NSString* PHConfigPath = @"~/.phoenix.js";
     
     [ctx evaluateScript:config];
     [self setupConfigWatcher];
-    
+}
+
+- (void) reloadWithAlert {
+    [self reload];
     [[PHAlerts sharedAlerts] show:@"Phoenix config loaded" duration:1.0];
 }
 
@@ -101,7 +104,7 @@ static NSString* PHConfigPath = @"~/.phoenix.js";
     ctx[@"api"] = api;
     
     api[@"reload"] = ^(NSString* str) {
-        [self reload];
+        [self reloadWithAlert];
     };
     
     api[@"launch"] = ^(NSString* appName) {


### PR DESCRIPTION
Solves #18. Config load alert will not be displayed after launch, but is still displayed for manual reloads and configuration file changes.