### PR TITLE
Anchor notifications at left

### DIFF
--- a/Phoenix/PHAlerts.m
+++ b/Phoenix/PHAlerts.m
@@ -146,7 +146,7 @@
     CGRect screenRect = [currentScreen frame];
     CGRect winRect = [[self window] frame];
     
-    winRect.origin.x = (screenRect.size.width / 2.0) - (winRect.size.width / 2.0);
+    winRect.origin.x = 0;
     winRect.origin.y = pushDownBy - winRect.size.height;
     
     [self.window setFrame:winRect display:NO];


### PR DESCRIPTION
Probably not the best way to fix this, but on my setup (Thunderbolt
display + MBP below its bottom right corner), notifications were being
placed past the right side of the MBP display.

This change makes them readable again on the left side of the MBP.

I'm new to Objective C programming.  If a better fix is needed, let me know how I can help you debug.