### PR TITLE
Expose bundle identifier in App

### DIFF
--- a/Phoenix/PHApp.h
+++ b/Phoenix/PHApp.h
@@ -19,6 +19,7 @@
 - (NSArray*) visibleWindows;
 
 - (NSString*) title;
+- (NSString*) bundleIdentifier;
 - (BOOL) isHidden;
 - (void) show;
 - (void) hide;

--- a/Phoenix/PHApp.m
+++ b/Phoenix/PHApp.m
@@ -123,6 +123,10 @@
     return [[NSRunningApplication runningApplicationWithProcessIdentifier:self.pid] localizedName];
 }
 
+- (NSString*) bundleIdentifier {
+    return [[NSRunningApplication runningApplicationWithProcessIdentifier:self.pid] bundleIdentifier];
+}
+
 - (void) activate {
     NSRunningApplication* app = [NSRunningApplication
                                  runningApplicationWithProcessIdentifier:self.pid];


### PR DESCRIPTION
Google Chrome and Google Chrome Canary both report their App title as "Google Chrome", which makes them hard to control them separately. Their bundle identifier, however, is different: `com.google.Chrome` and `com.google.Chrome.canary`. 